### PR TITLE
implement single-page functionality

### DIFF
--- a/baseapp/settings.py
+++ b/baseapp/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework'
 ]
 
 MIDDLEWARE = [

--- a/baseapp/urls.py
+++ b/baseapp/urls.py
@@ -15,10 +15,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from ui.views import index, services, about
+from ui.views import index, load_single
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('home/', index, name='index'),
-    path('services/', services, name='services'),
-    path('about/', about, name='about')
+    path('load_single/', load_single),
+    path('<slug:page>/', index),
 ]

--- a/baseapp/urls.py
+++ b/baseapp/urls.py
@@ -15,9 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from ui.views import index, load_single
+from ui.views import index, load_single, ContactUs
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('load_single/', load_single),
     path('<slug:page>/', index),
+    path('api/contact/', ContactUs.as_view())
 ]

--- a/ui/static/assets/js/atomic.js
+++ b/ui/static/assets/js/atomic.js
@@ -5,34 +5,26 @@
 *  or false if we are navigating via browser forward/back and no new state should be pushed.
 */
 function swapPage(target, should_push) {
+	// just a silly spinner
 	$("#single_page").append("<div class='sp-div'><div class='loader'></div></div>");
 	// fetch contents of the new page that we are changing to.
-	$.get("/" + target + "/", function(data) {
+	$.get("/load_single/?f=" + target, function(data) {
 		// parse the document using DOMParser API
 		var htmlDoc = (new DOMParser()).parseFromString(data, "text/html");
-		// insert contents of #single_page into body
-		$("#single_page").html(htmlDoc.getElementById("single_page").innerHTML);
-		// get title of loaded document
-		var new_title = htmlDoc.getElementsByTagName("title")[0].innerText;
-		// push history state and update URL
-		if (should_push) window.history.pushState({target: target}, new_title, "/" + target + "/");
+		// insert contents of the body of the pulled doc into #single_page
+		$("#single_page").html(htmlDoc.getElementsByTagName("body")[0].innerHTML);
+		// insert into history
+		if (should_push) window.history.pushState({target: target}, document.title, "/" + target + "/");
 	});
 }
 
-/**
-* Handles backward/forward navigation.
-*/
-function historyChange(event) {
-	if (event.state == undefined || event.state == null) return true;
-	// get the location we want to swap page to
-	var target = event.state.target;
-	// if it's undefined we can just let the browser handle this
-	if (target === undefined) return true;
-	// else, we handle the page swap
-	swapPage(target, false);
+function initSP(target) {
+	swapPage(target, true);
 }
 
-// setup. we need to put some data into the current state.
-window.history.replaceState({target: window.location.pathname.replace(/\//g, '')}, document.title, window.location.pathname);
-// bind event listener for state changes
-window.addEventListener('popstate', historyChange);
+window.addEventListener('popstate', function(event) {
+	if (event.state == null) return;
+	var target = event.state.target;
+	if (target == null) return;
+	swapPage(target, false);
+});

--- a/ui/static/assets/js/atomic.js
+++ b/ui/static/assets/js/atomic.js
@@ -7,17 +7,28 @@
 function swapPage(target, should_push) {
 	// just a silly spinner
 	$("#single_page").append("<div class='sp-div'><div class='loader'></div></div>");
-	// fetch contents of the new page that we are changing to.
-	$.get("/load_single/?f=" + target, function(data) {
-		// parse the document using DOMParser API
-		var htmlDoc = (new DOMParser()).parseFromString(data, "text/html");
+	if (target in window.cachedPages) {
 		// insert contents of the body of the pulled doc into #single_page
-		$("#single_page").html(htmlDoc.getElementsByTagName("body")[0].innerHTML);
+		$("#single_page").html(window.cachedPages[target].getElementsByTagName("body")[0].innerHTML);
 		// insert into history
 		if (should_push) window.history.pushState({target: target}, document.title, "/" + target + "/");
 		// fix navbar
 		$("#navPanel").html($('#nav').html() + '<a href="#navPanel" class="close"></a>');
-	});
+	} else {
+		// fetch contents of the new page that we are changing to.
+		$.get("/load_single/?f=" + target, function(data) {
+			// parse the document using DOMParser API
+			var htmlDoc = (new DOMParser()).parseFromString(data, "text/html");
+			// insert into cache
+			window.cachedPages[target] = htmlDoc;
+			// insert contents of the body of the pulled doc into #single_page
+			$("#single_page").html(htmlDoc.getElementsByTagName("body")[0].innerHTML);
+			// insert into history
+			if (should_push) window.history.pushState({target: target}, document.title, "/" + target + "/");
+			// fix navbar
+			$("#navPanel").html($('#nav').html() + '<a href="#navPanel" class="close"></a>');
+		});
+	}
 }
 
 function initSP(target) {
@@ -30,3 +41,5 @@ window.addEventListener('popstate', function(event) {
 	if (target == null) return;
 	swapPage(target, false);
 });
+
+window.cachedPages = {};

--- a/ui/static/assets/js/atomic.js
+++ b/ui/static/assets/js/atomic.js
@@ -15,6 +15,8 @@ function swapPage(target, should_push) {
 		$("#single_page").html(htmlDoc.getElementsByTagName("body")[0].innerHTML);
 		// insert into history
 		if (should_push) window.history.pushState({target: target}, document.title, "/" + target + "/");
+		// fix navbar
+		$("#navPanel").html($('#nav').html() + '<a href="#navPanel" class="close"></a>');
 	});
 }
 

--- a/ui/templates/about.html
+++ b/ui/templates/about.html
@@ -1,29 +1,14 @@
-<!DOCTYPE HTML>
-<!--
-	Projection by TEMPLATED
-	templated.co @templatedco
-	Released for free under the Creative Commons Attribution 3.0 license (templated.co/license)
--->
-<html>
-	<head>
-		<title>E-TEC</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		{% load static %}
-		<link rel="stylesheet" href="{% static 'assets/css/main.css' %}" />
-        <link rel="stylesheet" href="{% static 'assets/css/atomic.css' %}" />
-	</head>
-	<body id="single_page">
+{% load static %}
 		<!-- Header -->
 			<header id="header" style="background: #6cc091;">
 				<div class="inner">
-					<a href="#" onclick="swapPage('home', true);" class="logo">
+					<a href="javascript:void(0);" onclick="swapPage('home', true);" class="logo">
                         <img src="{% static 'images/logo.png' %}" style="width: 40px; height: 40px; margin-top: 5px" alt="E-TEC">
                     </a>
                     <nav id="nav">
-                        <a href="#" onclick="swapPage('home', true);">Home</a>
-                        <a href="#" onclick="swapPage('services', true);">Services</a>
-                        <a href="#" onclick="swapPage('about', true);">About</a>
+                        <a href="javascript:void(0);" onclick="swapPage('home', true);">Home</a>
+                        <a href="javascript:void(0);" onclick="swapPage('services', true);">Services</a>
+                        <a href="javascript:void(0);" onclick="swapPage('about', true);">About</a>
                     </nav>
 					<a href="#navPanel" class="navPanelToggle"><span class="fa fa-bars"></span></a>
 				</div>
@@ -94,17 +79,8 @@
                             </div>
                         </div>
                     <div class="copyright">
-                        &copy;<a href="#" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
+                        &copy;<a href="javascript:void(0);" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
                     </div>
                     
                 </div>
             </footer>
-
-            <!-- Scripts -->
-            <script src="{% static 'assets/js/jquery.min.js' %}"></script>
-            <script src="{% static 'assets/js/skel.min.js' %}"></script>
-            <script src="{% static 'assets/js/util.js' %}"></script>
-            <script src="{% static 'assets/js/main.js' %}"></script>
-            <script src="{% static 'assets/js/atomic.js' %}"></script>
-    </body>
-</html>

--- a/ui/templates/home.html
+++ b/ui/templates/home.html
@@ -1,0 +1,151 @@
+{% load static %}
+<!-- Header -->
+			<header id="header">
+				<div class="inner">
+					<a href="javascript:void(0);" onclick="swapPage('home', true);" class="logo">
+						<img src="{% static 'images/logo.png' %}" style="width: 60px; height: 60px;" alt="E-TEC">
+					</a>
+					<nav id="nav">
+						<a href="javascript:void(0);" onclick="swapPage('home', true);">Home</a>
+						<a href="javascript:void(0);" onclick="swapPage('services', true);">Services</a>
+						<a href="javascript:void(0);" onclick="swapPage('about', true);">About</a>
+					</nav>
+					<a href="#navPanel" class="navPanelToggle"><span class="fa fa-bars"></span></a>
+				</div>
+			</header>
+
+		<!-- Banner -->
+			<section id="banner">
+				<div class="inner">
+					<header>
+						<h1>Welcome to E-TEC</h1>
+						<p>Excellence Training and Education Company<br>
+							We provide specialized training programs for your workforce.</p>
+					</header>
+
+					<div class="flex ">
+
+						<div>
+							<span class="icon fa-clone"></span>
+							<h3>Excel</h3>
+							<p>Efficient, data trends, great charts.</p>
+						</div>
+
+						<div>
+							<span class="icon fa-bolt"></span>
+							<h3>Management</h3>
+							<p>Leadership, strategy, work culture.</p>
+						</div>
+
+						<div>
+							<span class="icon fa-eye"></span>
+							<h3>Policy</h3>
+							<p>Security, governance, cultural.</p>
+						</div>
+
+					</div>
+
+					<footer>
+						<a href="#" class="button">Get Started</a>
+					</footer>
+				</div>
+			</section>
+
+
+		<!-- Three -->
+			<section id="three" class="wrapper align-center">
+				<div class="inner">
+					<div class="flex flex-2">
+						<article>
+							<div class="image">
+								<img src="{% static 'images/excel.png' %}" alt="Excel" />
+							</div>
+							<header>
+								<h3>Create New<br /> Insights</h3>
+							</header>
+							<p>
+								Excel is a powerful productivity tool to have.<br />
+								Ensure your employees take full advantage <br />
+								by learning the fundemental techniques.
+							</p>
+							<footer>
+								<a href="#" class="button">Learn More</a>
+							</footer>
+						</article>
+						<article>
+							<div class="image">
+								<img src="{% static 'images/culture.png' %}" alt="Culture" />
+							</div>
+							<header>
+								<h3>Build Great<br /> Work Culture</h3>
+							</header>
+							<p>
+								Invest in your workforce. Bring your team together <br />
+								with educational leadership and teamwork services.<br />
+								Unlock the potential of your people.</p>
+							<footer>
+								<a href="#" class="button">Learn More</a>
+							</footer>
+						</article>
+					</div>
+				</div>
+			</section>
+
+		<!-- Footer -->
+			<footer id="footer">
+				<div class="inner">
+
+					<h3>Get in touch</h3>
+
+					<form action="#" method="post">
+
+						<div class="field half first">
+							<label for="name">Name</label>
+							<input name="name" id="name" type="text" placeholder="Name">
+						</div>
+						<div class="field half">
+							<label for="email">Email</label>
+							<input name="email" id="email" type="email" placeholder="Email">
+						</div>
+						<div class="field">
+							<label for="message">Message</label>
+							<textarea name="message" id="message" rows="6" placeholder="Message"></textarea>
+						</div>
+						<ul class="actions">
+							<li><input value="Send Message" class="button alt" type="submit"></li>
+						</ul>
+					</form>
+					<hr class="major" />
+					<div class="row">
+							<!-- Break -->
+							<div class="4u 12u$(medium)">
+								<h3>Our Address</h3>
+								<p>
+									E-TEC <br>
+									12 Spadina Road, Unit 520 <br>
+									Toronto, Ontario <br> 
+									M2C, 5E7
+								</p>
+							</div>
+							<div class="4u 12u$(medium)">
+								<h3>Contact Us</h3>
+								<p>
+									647-201-4812 <br>
+									welcome@e-tec.ca
+								</p>
+							</div>
+							<div class="4u$ 12u$(medium)">
+								<h3>Social Media</h3>
+								<p>
+									<span class="icon fa-facebook-f right">&emsp; pages/etec</span> <br>
+									<span class="icon fa-instagram right"> &emsp; @e-tec</span> <br>
+									<span class="icon fa-linkedin right">&emsp; e-tec</span>
+								</p>
+							</div>
+						</div>
+					<div class="copyright">
+						&copy;<a href="javascript:void(0);" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
+					</div>
+					
+				</div>
+			</footer>

--- a/ui/templates/home.html
+++ b/ui/templates/home.html
@@ -97,7 +97,7 @@
 
 					<h3>Get in touch</h3>
 
-					<form action="#" method="post">
+					<form onsubmit="return contact_us();">
 
 						<div class="field half first">
 							<label for="name">Name</label>
@@ -110,6 +110,9 @@
 						<div class="field">
 							<label for="message">Message</label>
 							<textarea name="message" id="message" rows="6" placeholder="Message"></textarea>
+						</div>
+						<div id="error_contact">
+
 						</div>
 						<ul class="actions">
 							<li><input value="Send Message" class="button alt" type="submit"></li>
@@ -149,3 +152,39 @@
 					
 				</div>
 			</footer>
+
+			<script type="text/javascript">
+				function contact_us() {
+					// get variables
+					var name = $("#name").val();
+					var mail = $("#email").val();
+					var message = $("#message").val();
+
+					// confirm all fields are filled out
+					if (name == "" || mail == "" || message == "") {
+						$("#error_contact").html("<p>Please fill out all fields.</p>");
+						return false;
+					}
+
+					// check if mail is a valid email address
+					if (!validateEmail(mail)) {
+						$("#error_contact").html("<p>E-mail address is in an incorrect format.</p>");
+						return false;
+					}
+
+					// ajax call to send email
+					$.post("/api/contact/", {name: name, mail: mail, message: message}, function(data) {
+						$("#error_contact").html("<p>E-mail has been sent to E-TEC successfully.</p>");
+					}).fail(function(jqXHR) {
+						$("#error_contact").html("<p>Failed to send email to E-TEC.</p>");
+						$("#error_contact").append("<p>" + jqXHR.responseJSON.error + "</p>");
+					});
+
+					return false;
+				}
+
+				function validateEmail(email) {
+					var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+					return re.test(email);
+				}
+			</script>

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -13,164 +13,22 @@
 		<link rel="stylesheet" href="{% static 'assets/css/main.css' %}" />
 		<link rel="stylesheet" href="{% static 'assets/css/atomic.css' %}" />
 	</head>
-	<body id="single_page">
+	<body>
 
-		<!-- Header -->
-			<header id="header">
-				<div class="inner">
-					<a href="#" onclick="swapPage('home', true);" class="logo">
-						<img src="{% static 'images/logo.png' %}" style="width: 60px; height: 60px;" alt="E-TEC">
-					</a>
-					<nav id="nav">
-						<a href="#" onclick="swapPage('home', true);">Home</a>
-						<a href="#" onclick="swapPage('services', true);">Services</a>
-						<a href="#" onclick="swapPage('about', true);">About</a>
-					</nav>
-					<a href="#navPanel" class="navPanelToggle"><span class="fa fa-bars"></span></a>
-				</div>
-			</header>
-
-		<!-- Banner -->
-			<section id="banner">
-				<div class="inner">
-					<header>
-						<h1>Welcome to E-TEC</h1>
-						<p>Excellence Training and Education Company<br>
-							We provide specialized training programs for your workforce.</p>
-					</header>
-
-					<div class="flex ">
-
-						<div>
-							<span class="icon fa-clone"></span>
-							<h3>Excel</h3>
-							<p>Efficient, data trends, great charts.</p>
-						</div>
-
-						<div>
-							<span class="icon fa-bolt"></span>
-							<h3>Management</h3>
-							<p>Leadership, strategy, work culture.</p>
-						</div>
-
-						<div>
-							<span class="icon fa-eye"></span>
-							<h3>Policy</h3>
-							<p>Security, governance, cultural.</p>
-						</div>
-
-					</div>
-
-					<footer>
-						<a href="#" class="button">Get Started</a>
-					</footer>
-				</div>
-			</section>
-
-
-		<!-- Three -->
-			<section id="three" class="wrapper align-center">
-				<div class="inner">
-					<div class="flex flex-2">
-						<article>
-							<div class="image">
-								<img src="{% static 'images/excel.png' %}" alt="Excel" />
-							</div>
-							<header>
-								<h3>Create New<br /> Insights</h3>
-							</header>
-							<p>
-								Excel is a powerful productivity tool to have.<br />
-								Ensure your employees take full advantage <br />
-								by learning the fundemental techniques.
-							</p>
-							<footer>
-								<a href="#" class="button">Learn More</a>
-							</footer>
-						</article>
-						<article>
-							<div class="image">
-								<img src="{% static 'images/culture.png' %}" alt="Culture" />
-							</div>
-							<header>
-								<h3>Build Great<br /> Work Culture</h3>
-							</header>
-							<p>
-								Invest in your workforce. Bring your team together <br />
-								with educational leadership and teamwork services.<br />
-								Unlock the potential of your people.</p>
-							<footer>
-								<a href="#" class="button">Learn More</a>
-							</footer>
-						</article>
-					</div>
-				</div>
-			</section>
-
-		<!-- Footer -->
-			<footer id="footer">
-				<div class="inner">
-
-					<h3>Get in touch</h3>
-
-					<form action="#" method="post">
-
-						<div class="field half first">
-							<label for="name">Name</label>
-							<input name="name" id="name" type="text" placeholder="Name">
-						</div>
-						<div class="field half">
-							<label for="email">Email</label>
-							<input name="email" id="email" type="email" placeholder="Email">
-						</div>
-						<div class="field">
-							<label for="message">Message</label>
-							<textarea name="message" id="message" rows="6" placeholder="Message"></textarea>
-						</div>
-						<ul class="actions">
-							<li><input value="Send Message" class="button alt" type="submit"></li>
-						</ul>
-					</form>
-					<hr class="major" />
-					<div class="row">
-							<!-- Break -->
-							<div class="4u 12u$(medium)">
-								<h3>Our Address</h3>
-								<p>
-									E-TEC <br>
-									12 Spadina Road, Unit 520 <br>
-									Toronto, Ontario <br> 
-									M2C, 5E7
-								</p>
-							</div>
-							<div class="4u 12u$(medium)">
-								<h3>Contact Us</h3>
-								<p>
-									647-201-4812 <br>
-									welcome@e-tec.ca
-								</p>
-							</div>
-							<div class="4u$ 12u$(medium)">
-								<h3>Social Media</h3>
-								<p>
-									<span class="icon fa-facebook-f right">&emsp; pages/etec</span> <br>
-									<span class="icon fa-instagram right"> &emsp; @e-tec</span> <br>
-									<span class="icon fa-linkedin right">&emsp; e-tec</span>
-								</p>
-							</div>
-						</div>
-					<div class="copyright">
-						&copy;<a href="#" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
-					</div>
-					
-				</div>
-			</footer>
+		<div id="single_page">
+		</div>
 
 		<!-- Scripts -->
-			<script src="{% static 'assets/js/jquery.min.js' %}"></script>
-			<script src="{% static 'assets/js/skel.min.js' %}"></script>
-			<script src="{% static 'assets/js/util.js' %}"></script>
-			<script src="{% static 'assets/js/main.js' %}"></script>
-			<script src="{% static 'assets/js/atomic.js' %}"></script>
+		<script src="{% static 'assets/js/jquery.min.js' %}"></script>
+		<script src="{% static 'assets/js/skel.min.js' %}"></script>
+		<script src="{% static 'assets/js/util.js' %}"></script>
+		<script src="{% static 'assets/js/main.js' %}"></script>
+		<script src="{% static 'assets/js/atomic.js' %}"></script>
+
+		<script type="text/javascript">
+			$(document).ready(function() {
+				initSP("{{ page }}");
+			});
+		</script>
 	</body>
 </html>

--- a/ui/templates/services.html
+++ b/ui/templates/services.html
@@ -1,29 +1,14 @@
-<!DOCTYPE HTML>
-<!--
-	Projection by TEMPLATED
-	templated.co @templatedco
-	Released for free under the Creative Commons Attribution 3.0 license (templated.co/license)
--->
-<html>
-	<head>
-		<title>E-TEC</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		{% load static %}
-		<link rel="stylesheet" href="{% static 'assets/css/main.css' %}" />
-		<link rel="stylesheet" href="{% static 'assets/css/atomic.css' %}" />
-	</head>
-	<body id="single_page">
+{% load static %}
 		<!-- Header -->
 			<header id="header" style="background: #6cc091;">
 				<div class="inner">
-					<a href="#" onclick="swapPage('home', true);" class="logo">
+					<a href="javascript:void(0);" onclick="swapPage('home', true);" class="logo">
 						<img src="{% static 'images/logo.png' %}" style="width: 40px; height: 40px; margin-top: 5px" alt="E-TEC">
 					</a>
 					<nav id="nav">
-						<a href="#" onclick="swapPage('home', true);">Home</a>
-						<a href="#" onclick="swapPage('services', true);">Services</a>
-						<a href="#" onclick="swapPage('about', true);">About</a>
+						<a href="javascript:void(0);" onclick="swapPage('home', true);">Home</a>
+						<a href="javascript:void(0);" onclick="swapPage('services', true);">Services</a>
+						<a href="javascript:void(0);" onclick="swapPage('about', true);">About</a>
 					</nav>
 					<a href="#navPanel" class="navPanelToggle"><span class="fa fa-bars"></span></a>
 				</div>
@@ -128,17 +113,8 @@
                             </div>
                         </div>
                     <div class="copyright">
-						&copy;<a href="#" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
+						&copy;<a href="javascript:void(0);" onclick="swapPage('home', true);">E-TEC</a>. Design: <a href="https://atomictech.ca">Atomic Tech</a>. 
 					</div>
                     
                 </div>
             </footer>
-
-            <!-- Scripts -->
-			<script src="{% static 'assets/js/jquery.min.js' %}"></script>
-			<script src="{% static 'assets/js/skel.min.js' %}"></script>
-			<script src="{% static 'assets/js/util.js' %}"></script>
-			<script src="{% static 'assets/js/main.js' %}"></script>
-			<script src="{% static 'assets/js/atomic.js' %}"></script>
-    </body>
-</html>

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,4 +1,12 @@
 from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+import re
+
+import smtplib
+from email.mime.text import MIMEText
 
 # Create your views here.
 def index(request, page):
@@ -7,3 +15,32 @@ def index(request, page):
 def load_single(request):
 	source_file = request.GET.get('f', 'home') + ".html"
 	return render(request, source_file)
+
+class ContactUs(APIView):
+
+	def post(self, request):
+		if not 'name' in request.data or not 'mail' in request.data or not 'message' in request.data:
+			return Response(status=status.HTTP_400_BAD_REQUEST, data={"error": "Parameters are missing from the contact request."})
+
+		# check email address loosely
+		if not re.match(r"[^@]+@[^@]+\.[^@]+", request.data['mail']):
+			return Response(status=status.HTTP_400_BAD_REQUEST, data={"error": "E-mail address is not in a valid format."})
+
+		# perform email
+		name = request.data['name']
+		email = request.data['mail']
+		message = request.data['message']
+		msg = MIMEText("Someone has reached out via the E-TEC Contact form.\nName: " + name + "\nEmail: " + email + "\nMessage: " + message)
+
+		msg['Subject'] = "New Contact on E-TEC"
+		msg['From'] = "noreply@e-tec.ca"
+
+		# fill in valid smtp server here (possibly gmail's servers)
+		s = smtplib.SMTP_SSL('')
+		# fill in valid credentials for smtp server here, if needed
+		s.login('','')
+		# fill in the recipients for the email here
+		s.sendmail('noreply@e-tec.ca',[''], msg.as_string())
+		s.quit()
+
+		return Response()

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,9 +1,9 @@
 from django.shortcuts import render
 
 # Create your views here.
-def index(request):
-    return render(request, "index.html")
-def services(request):
-    return render(request, "services.html")
-def about(request):
-    return render(request, "about.html")
+def index(request, page):
+    return render(request, "index.html", context={"page": page})
+
+def load_single(request):
+	source_file = request.GET.get('f', 'home') + ".html"
+	return render(request, source_file)


### PR DESCRIPTION
basically the way it works is -

base page index.html is rendered, it has a div with id=single_page where page content is inserted into.
include the atomic.js and atomic.css on index.html to set up single-page functionality.

any request that comes in to the site will get matched by this rule in urls.py:
`path('<slug:page>/', index),`
and be dispatched to index view. index view passes the requested page through to index.html (e.g. passes 'home' through in context if you navigate to /home/).

then the application pulls data from /load_single/?f=(page name) (e.g. /load_single/?f=home) - this will grab the contents of (page name).html, e.g. home.html, and insert it into the single_page div. this doesn't have to be a full html page, it can be just the contents of the page without any css, js, meta tags, etc.

because the stuff it loads gets parsed by django we can use django tags (e.g. static) in the loaded contents.

we use the function swapPage(page_name, should_push) to swap pages, this function basically clears out the contents of the single_page div, loads the new contents, and adds an entry to the browser history (which both gives state information and modifies the URL). this lets us load the right pages back up if user presses the back button.